### PR TITLE
need detached process flag on windows 11

### DIFF
--- a/teleprox/process.py
+++ b/teleprox/process.py
@@ -236,8 +236,8 @@ def start_process(
             popen_kwargs[
                 'creationflags'
             ] = (
-                subprocess.CREATE_NEW_PROCESS_GROUP
-            )  # subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+                subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+            )
     else:
         if log_stdio is True:
             popen_kwargs['stdout'] = subprocess.PIPE


### PR DESCRIPTION
This fixes the issue where daemon processes stay attached to their console on W11 (but I think it was not needed on W10?)