### PR TITLE
feat: process-level call hooks for RPCClient and RPCServer

### DIFF
--- a/teleprox/client.py
+++ b/teleprox/client.py
@@ -24,6 +24,26 @@ from .log import DEBUG1, DEBUG2, DEBUG3
 logger = logging.getLogger(__name__)
 
 
+# Process-level provider called before each outgoing call_obj to supply extra opts.
+# Set via set_call_opts_provider(). Signature: () -> dict | None
+_call_opts_provider = None
+
+
+def set_call_opts_provider(fn):
+    """Register a process-level provider that adds extra opts to every outgoing call_obj.
+
+    The provider is called with no arguments before each call_obj request and should
+    return a dict of extra opts to merge into the call, or None.  Only one provider
+    can be registered at a time; calling this again replaces the previous one.
+
+    Use this to attach call-time metadata (e.g. tracing context) that the receiving
+    RPCServer can inspect via a complementary hook registered with
+    :func:`teleprox.server.set_call_context_hook`.
+    """
+    global _call_opts_provider
+    _call_opts_provider = fn
+
+
 class RPCClient(object):
     """Connection to an :class:`RPCServer`.
 
@@ -388,6 +408,10 @@ class RPCClient(object):
             All extra keyword arguments are passed to :func:`send() <RPCClient.send>`.
         """
         opts = {'obj': obj, 'args': args, 'kwargs': kwargs}
+        if _call_opts_provider is not None:
+            extra = _call_opts_provider()
+            if extra:
+                opts.update(extra)
         return self.send('call_obj', opts=opts, **kwds)
 
     def get_obj(self, obj, **kwds):

--- a/teleprox/server.py
+++ b/teleprox/server.py
@@ -1,5 +1,6 @@
 import atexit
 import builtins
+import contextlib
 import logging
 import sys
 import threading
@@ -8,6 +9,26 @@ import traceback
 import zmq
 
 from . import log
+
+
+# Process-level hook called around each incoming call_obj execution.
+# Set via set_call_context_hook(). Signature: (opts: dict) -> context manager
+_call_context_hook = None
+
+
+def set_call_context_hook(fn):
+    """Register a process-level hook that wraps every incoming call_obj execution.
+
+    The hook is called with the full opts dict for the call_obj action and must
+    return a context manager.  The remote callable is invoked inside that context
+    manager, so the hook can set up (and tear down) any per-call state.
+
+    Only one hook can be registered at a time; calling this again replaces the
+    previous one.  Pair with :func:`teleprox.client.set_call_opts_provider` to
+    propagate metadata from the calling process into the receiving process.
+    """
+    global _call_context_hook
+    _call_context_hook = fn
 from . import serializer
 from .proxy import ObjectProxy
 from .timer import Timer
@@ -339,15 +360,17 @@ class RPCServer(object):
             fnargs = opts.get('args', ())
             fnkwds = opts.get('kwargs', {})
 
+            call_cm = _call_context_hook(opts) if _call_context_hook is not None else contextlib.nullcontext()
             # need to do this because some functions do not allow keyword arguments.
-            if len(fnkwds) == 0:
-                try:
-                    result = obj(*fnargs)
-                except Exception:
-                    logger.warning("Failed to call object %s: %d, %s", obj, len(fnargs), fnargs[1:])
-                    raise
-            else:
-                result = obj(*fnargs, **fnkwds)
+            with call_cm:
+                if len(fnkwds) == 0:
+                    try:
+                        result = obj(*fnargs)
+                    except Exception:
+                        logger.warning("Failed to call object %s: %d, %s", obj, len(fnargs), fnargs[1:])
+                        raise
+                else:
+                    result = obj(*fnargs, **fnkwds)
             # logger.debug("    => call_obj result: %r", result)
         elif action == 'get_obj':
             result = opts['obj']

--- a/teleprox/tests/test_call_hooks.py
+++ b/teleprox/tests/test_call_hooks.py
@@ -1,0 +1,224 @@
+# Tests for process-level call hooks: set_call_opts_provider and set_call_context_hook.
+import contextlib
+import threading
+import time
+
+import pytest
+import teleprox
+import teleprox.client as tc
+import teleprox.server as ts
+from teleprox import RPCClient, RPCServer
+from teleprox.util import ProcessCleaner
+from teleprox.tests.util import RemoteLogRecorder
+
+
+@pytest.fixture(autouse=True)
+def reset_hooks():
+    """Restore module-level hooks to None after every test."""
+    yield
+    tc.set_call_opts_provider(None)
+    ts.set_call_context_hook(None)
+
+
+# ---------------------------------------------------------------------------
+# set_call_opts_provider
+# ---------------------------------------------------------------------------
+
+def test_opts_provider_extra_opts_reach_server():
+    """Extras from the provider appear in opts seen by process_action."""
+    received_opts = []
+
+    server = RPCServer()
+
+    orig = server.process_action
+    def capturing_process_action(action, opts, return_type, caller):
+        if action == 'call_obj':
+            received_opts.append(dict(opts))
+        return orig(action, opts, return_type, caller)
+    server.process_action = capturing_process_action
+
+    tc.set_call_opts_provider(lambda: {'_test_extra': 'hello'})
+
+    client = RPCClient(server.address)
+    client._import('os').getpid()
+    client.close_server()
+
+    assert any(o.get('_test_extra') == 'hello' for o in received_opts)
+
+
+def test_opts_provider_none_return_is_ignored():
+    """A provider returning None does not modify opts."""
+    received_opts = []
+
+    server = RPCServer()
+    orig = server.process_action
+    def capturing(action, opts, return_type, caller):
+        if action == 'call_obj':
+            received_opts.append(dict(opts))
+        return orig(action, opts, return_type, caller)
+    server.process_action = capturing
+
+    tc.set_call_opts_provider(lambda: None)
+
+    client = RPCClient(server.address)
+    client._import('os').getpid()
+    client.close_server()
+
+    assert all('_test_extra' not in o for o in received_opts)
+
+
+def test_clearing_opts_provider():
+    """Setting the provider to None stops extra opts from being sent."""
+    tc.set_call_opts_provider(lambda: {'_should_not_appear': True})
+    tc.set_call_opts_provider(None)
+
+    received_opts = []
+    server = RPCServer()
+    orig = server.process_action
+    def capturing(action, opts, return_type, caller):
+        if action == 'call_obj':
+            received_opts.append(dict(opts))
+        return orig(action, opts, return_type, caller)
+    server.process_action = capturing
+
+    client = RPCClient(server.address)
+    client._import('os').getpid()
+    client.close_server()
+
+    assert all('_should_not_appear' not in o for o in received_opts)
+
+
+# ---------------------------------------------------------------------------
+# set_call_context_hook
+# ---------------------------------------------------------------------------
+
+def test_context_hook_is_entered_and_exited():
+    """The context manager returned by the hook wraps the call."""
+    events = []
+
+    @contextlib.contextmanager
+    def hook(opts):
+        events.append('enter')
+        yield
+        events.append('exit')
+
+    ts.set_call_context_hook(hook)
+
+    server = RPCServer()
+    client = RPCClient(server.address)
+    client._import('os').getpid()
+    client.close_server()
+
+    assert events == ['enter', 'exit']
+
+
+def test_context_hook_receives_opts():
+    """The hook receives the full opts dict for the call."""
+    received = []
+
+    @contextlib.contextmanager
+    def hook(opts):
+        received.append(opts.copy())
+        yield
+
+    ts.set_call_context_hook(hook)
+
+    server = RPCServer()
+    client = RPCClient(server.address)
+    client._import('os').getpid()
+    client.close_server()
+
+    assert len(received) == 1
+    assert 'obj' in received[0]
+
+
+def test_context_hook_sees_extra_opts_from_provider():
+    """Hook opts include extras injected by the client-side provider."""
+    received = []
+
+    tc.set_call_opts_provider(lambda: {'_ctx': 'propagated'})
+
+    @contextlib.contextmanager
+    def hook(opts):
+        received.append(opts.get('_ctx'))
+        yield
+
+    ts.set_call_context_hook(hook)
+
+    server = RPCServer()
+    client = RPCClient(server.address)
+    client._import('os').getpid()
+    client.close_server()
+
+    assert received == ['propagated']
+
+
+def test_hook_not_called_for_non_call_obj_actions():
+    """The context hook is only invoked for call_obj, not for import/get_item/etc."""
+    call_count = [0]
+
+    @contextlib.contextmanager
+    def hook(opts):
+        call_count[0] += 1
+        yield
+
+    ts.set_call_context_hook(hook)
+
+    server = RPCServer()
+    client = RPCClient(server.address)
+    _ = client['self']          # get_item
+    client.close_server()       # close
+
+    assert call_count[0] == 0
+
+
+def test_hook_called_once_per_call():
+    """The hook is entered exactly once per remote callable invocation."""
+    count = [0]
+
+    @contextlib.contextmanager
+    def hook(opts):
+        count[0] += 1
+        yield
+
+    ts.set_call_context_hook(hook)
+
+    server = RPCServer()
+    client = RPCClient(server.address)
+    ros = client._import('os')
+    ros.getpid()
+    ros.getpid()
+    client.close_server()
+
+    # two call_obj actions: the import itself + two getpid calls
+    assert count[0] >= 2
+
+
+# ---------------------------------------------------------------------------
+# Cross-process smoke test
+# ---------------------------------------------------------------------------
+
+def test_cross_process_opts_and_hook():
+    """Provider opts set in the parent are visible to the hook in the child."""
+    with RemoteLogRecorder('test_hooks_cross_process') as recorder:
+        proc = teleprox.start_process(name='test_hooks_child', log_addr=recorder.address)
+        try:
+            tc.set_call_opts_provider(lambda: {'_trace': 'from-parent'})
+
+            # Install a hook in the remote process that logs when it receives the extra.
+            proc.client._import('builtins').exec(
+                'import contextlib, logging, teleprox.server as ts\n'
+                '@contextlib.contextmanager\n'
+                'def h(opts):\n'
+                '    if opts.get("_trace"):\n'
+                '        logging.getLogger().warning("hook_trace:" + str(opts["_trace"]))\n'
+                '    yield\n'
+                'ts.set_call_context_hook(h)\n'
+            )
+
+            # Any further call will trigger the hook.
+            proc.client._import('os').getpid()
+        finally:
+            proc.stop()
+
+    assert recorder.find_message('hook_trace:from-parent') is not None


### PR DESCRIPTION
## Summary
- `teleprox.client.set_call_opts_provider(fn)`: register a process-global callable that adds extra opts to every outgoing `call_obj` request
- `teleprox.server.set_call_context_hook(fn)`: register a process-global callable that returns a context manager wrapping every incoming `call_obj` execution
- Pair them to propagate arbitrary per-call metadata (tracing context, task stacks, etc.) from caller to receiver with zero call-site changes

## Test plan
- [x] `pytest teleprox/tests/test_call_hooks.py` — 9 tests: unit tests for provider and hook independently, combined, edge cases, plus a cross-process smoke test

🤖 Generated with [Claude Code](https://claude.ai/code)