### PR TITLE
Gentletask throughline propagation through teleprox logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `LogSender.close()` now joins the sender thread before closing the socket, ensuring all queued log records are delivered when a process exits quickly
+
 ## [2.2.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `LogSender.close()` now joins the sender thread before closing the socket, ensuring all queued log records are delivered when a process exits quickly
+- A failed remote call's "Exception while processing request" error log now re-establishes the call's context hook while logging, so the failure record carries the same throughline a successful call would (previously the context window had already closed, leaving an empty chain)
 
 ## [2.2.1]
 

--- a/teleprox/__init__.py
+++ b/teleprox/__init__.py
@@ -6,3 +6,10 @@ from .qt_server import QtRPCServer
 from .proxy import ObjectProxy
 from .process import start_process, DaemonProcess, ChildProcess
 from .processspawner import ProcessSpawner  # for backward compatibility (use start_process instead)
+
+# Re-export the throughline submodule so callers can opt in to gentletask
+# throughline propagation across the process boundary:
+#     from teleprox import throughline
+#     throughline.enable_throughline_propagation()
+# Propagation is OPT-IN and is NOT wired up at import; see throughline.py.
+from . import throughline

--- a/teleprox/log/logviewer/constants.py
+++ b/teleprox/log/logviewer/constants.py
@@ -57,7 +57,7 @@ class LogColumns:
         'Logger',       # LOGGER
         'Level',        # LEVEL
         'Message',      # MESSAGE
-        'Task'          # TASK
+        'Throughline'   # TASK (gentletask throughline / task-name chain)
     ]
     
     # Default column widths
@@ -70,5 +70,5 @@ class LogColumns:
         100,    # LOGGER
         100,    # LEVEL
         400,    # MESSAGE
-        100     # TASK
+        250     # TASK (Throughline — task-name chain can be long)
     ]

--- a/teleprox/log/logviewer/log_model.py
+++ b/teleprox/log/logviewer/log_model.py
@@ -722,7 +722,14 @@ class LogModel(qt.QStandardItemModel):
             elif col_id == LogColumns.MESSAGE:
                 record._column_text_cache[col_id] = record.getMessage()
             elif col_id == LogColumns.TASK:
-                record._column_text_cache[col_id] = getattr(record, 'taskName', '')
+                # The gentletask throughline: the chain of task names active when
+                # the record was emitted (set by ThroughlineNameFilter). Falls back
+                # to a plain taskName for records without a throughline.
+                throughline = getattr(record, 'throughline', None)
+                if throughline:
+                    record._column_text_cache[col_id] = " > ".join(str(n) for n in throughline)
+                else:
+                    record._column_text_cache[col_id] = getattr(record, 'taskName', '')
             else:
                 record._column_text_cache[col_id] = ""
 

--- a/teleprox/log/logviewer/viewer.py
+++ b/teleprox/log/logviewer/viewer.py
@@ -231,9 +231,9 @@ class LogViewer(qt.QWidget):
         self.header.setContextMenuPolicy(qt.Qt.ContextMenuPolicy.CustomContextMenu)
         self.header.customContextMenuRequested.connect(self._show_header_context_menu)
 
-        # Hide Task, Level, Host, Process, and Thread columns by default
+        # Hide Level, Host, Process, and Thread columns by default. The Throughline
+        # (task-name chain) column is shown by default.
         self.tree.setColumnHidden(LogColumns.LEVEL, True)  # Level column
-        self.tree.setColumnHidden(LogColumns.TASK, True)  # Task column
         self.tree.setColumnHidden(LogColumns.HOST, True)  # Host column
         self.tree.setColumnHidden(LogColumns.PROCESS, True)  # Process column
         self.tree.setColumnHidden(LogColumns.THREAD, True)  # Thread column

--- a/teleprox/log/remote.py
+++ b/teleprox/log/remote.py
@@ -175,6 +175,10 @@ class LogSender(logging.Handler):
             if record is None:
                 break
             self._handle(record)
+        # Close socket here so all queued records are sent before it closes.
+        socket, self.socket = self.socket, None
+        if socket is not None:
+            socket.close()
 
     def _handle(self, record):
         global host_name, process_name, thread_names
@@ -271,9 +275,12 @@ class LogSender(logging.Handler):
         self.socket.connect(addr)
 
     def close(self):
-        # if this socket is left open when the process exits, it can lead to
-        # deadlock.
+        # Leaving the socket open when the process exits can cause deadlock;
+        # join the run thread so all queued records are sent before it closes
+        # the socket. The fallback handles the rare case where the thread times out.
         self.record_queue.put(None)
+        self.thread.join(timeout=5)
+        # Fallback: close socket if the run thread didn't get to it.
         socket, self.socket = self.socket, None
         if socket is not None:
             socket.close()

--- a/teleprox/log/remote.py
+++ b/teleprox/log/remote.py
@@ -13,6 +13,11 @@ import json
 import traceback
 import types
 
+try:
+    from gentletask import task_chain as _gt_task_chain
+except ImportError:  # gentletask is an optional dependency
+    _gt_task_chain = None
+
 logger = logging.getLogger(__name__)
 
 # Provide access to process and thread names for logging purposes.
@@ -166,6 +171,12 @@ class LogSender(logging.Handler):
     def handle(self, record):
         if not self.filter(record):
             return False
+        # Tag the record with the gentletask throughline here, in the emitting
+        # thread, so the originating process's task context travels to the log
+        # server (the send loop below runs on a different thread with no context).
+        # Set only if absent so an upstream filter's value is preserved.
+        if _gt_task_chain is not None and not hasattr(record, "throughline"):
+            record.throughline = _gt_task_chain()
         self.record_queue.put(record)
         return True
 

--- a/teleprox/server.py
+++ b/teleprox/server.py
@@ -275,6 +275,7 @@ class RPCServer(object):
         self._clients[caller] = ser_type
 
         # Attempt to read message and invoke requested action
+        opts = None
         try:
             try:
                 ser = self._serializers[ser_type]
@@ -293,8 +294,18 @@ class RPCServer(object):
             result = self.process_action(action, opts, return_type, caller)
             exc = None
         except Exception:
-            logger.exception("    => Exception while processing request %d", req_id)
             exc = sys.exc_info()
+            # Re-establish the call's semantic context (e.g. the gentletask
+            # throughline) while logging, so a failed call's error record
+            # carries the caller's task chain just as the call itself did.
+            # The context was active only inside process_action's `with
+            # call_cm` and is gone by the time control reaches here.
+            if _call_context_hook is not None and action == 'call_obj' and opts:
+                err_ctx = _call_context_hook(opts)
+            else:
+                err_ctx = contextlib.nullcontext()
+            with err_ctx:
+                logger.exception("    => Exception while processing request %d", req_id)
 
         # Send result or error back to client
         if req_id >= 0:

--- a/teleprox/tests/test_logsender_filters.py
+++ b/teleprox/tests/test_logsender_filters.py
@@ -1,4 +1,4 @@
-# Tests for LogSender.handle() respecting registered filters.
+# Tests for LogSender: filter behavior and close() flush guarantee.
 import logging
 import time
 
@@ -104,4 +104,37 @@ def test_multiple_filters_all_must_pass():
 
     assert 'should_not_reach_second_filter' not in delivered
     assert 'should_reach_second_filter' in delivered
+    recorder.stop()
+
+
+# ---------------------------------------------------------------------------
+# close() flush guarantee
+# ---------------------------------------------------------------------------
+
+def test_close_flushes_pending_records():
+    """close() must deliver all records queued before it is called.
+
+    Queue records faster than the run thread can drain them, then call close()
+    immediately. The pre-fix behavior was to close the socket before the thread
+    finished draining the queue, silently dropping records.
+    """
+    N = 50
+    recorder = RemoteLogRecorder('test_close_flush')
+    sender = LogSender(recorder.address)
+
+    for i in range(N):
+        sender.handle(logging.makeLogRecord({
+            'msg': f'close_flush_{i}',
+            'levelno': logging.INFO,
+            'levelname': 'INFO',
+        }))
+
+    sender.close()
+
+    # PUSH/PULL is ordered, so the last record arriving implies all earlier ones did too.
+    assert recorder.find_message(f'close_flush_{N - 1}') is not None, \
+        "Last record not delivered — close() did not flush the queue"
+    missing = [i for i in range(N) if recorder.handler.find_message(f'close_flush_{i}') is None]
+    assert missing == [], f"Records dropped during close(): {missing}"
+
     recorder.stop()

--- a/teleprox/tests/test_throughline.py
+++ b/teleprox/tests/test_throughline.py
@@ -141,3 +141,40 @@ def test_cross_process_throughline_ancestry():
             proc.stop()
 
     assert recorder.find_message("chain:parent_op,parent_step") is not None
+
+
+def test_cross_process_exception_log_carries_throughline():
+    """A remote call that RAISES logs its server-side error under the caller's chain.
+
+    The server's "Exception while processing request" record is emitted after the
+    call's context window (``with call_cm``) has closed.  The error path
+    re-establishes the transferred frames while logging, so the failure log
+    carries the same throughline a successful call would, rather than an empty
+    chain.
+    """
+    with RemoteLogRecorder("test_throughline_exc") as recorder:
+        proc = teleprox.start_process(
+            name="test_throughline_exc_child", log_addr=recorder.address
+        )
+        try:
+            proc.client._import("teleprox.throughline").enable_throughline_propagation()
+
+            # Define a remote function that always raises.
+            proc.client._import("builtins").exec(
+                "def _boom():\n"
+                "    raise ValueError('boom')\n"
+                "import builtins as _b; _b._boom = _boom\n"
+            )
+            boom = proc.client._import("builtins")._boom
+            with gentletask.throughline(name="parent_op"), gentletask.throughline(
+                name="parent_step"
+            ):
+                with pytest.raises(Exception):
+                    boom()
+        finally:
+            proc.stop()
+
+    rec = recorder.find_message("Exception while processing request")
+    assert rec is not None
+    # The chain survives the JSON round-trip as a list rather than a tuple.
+    assert list(getattr(rec, "throughline", ())) == ["parent_op", "parent_step"]

--- a/teleprox/tests/test_throughline.py
+++ b/teleprox/tests/test_throughline.py
@@ -1,0 +1,143 @@
+# Tests for automatic gentletask throughline propagation across the teleprox boundary.
+# Verifies that a caller's throughline frames are serialized into call opts and
+# re-established on the server before the remote callable runs.
+import contextlib
+
+import pytest
+
+import teleprox
+import teleprox.client as tc
+import teleprox.server as ts
+from teleprox import RPCClient, RPCServer
+from teleprox.tests.util import RemoteLogRecorder
+
+gentletask = pytest.importorskip("gentletask")
+from teleprox import throughline as tl  # noqa: E402  (imported after skip guard)
+
+
+@pytest.fixture(autouse=True)
+def propagation_enabled():
+    """Opt in to throughline propagation for the test, then tear it down.
+
+    Propagation is opt-in (no import-time auto-wiring), so each test enables it
+    explicitly here and disables it afterward, leaving the global provider/hook
+    slots clear for other tests.
+    """
+    tl.enable_throughline_propagation()
+    yield
+    tl.disable_throughline_propagation()
+
+
+# ---------------------------------------------------------------------------
+# Provider: client serializes its current throughline frames into opts
+# ---------------------------------------------------------------------------
+
+
+def test_provider_serializes_current_frames():
+    """The opts provider emits the caller's current throughline frames."""
+    with gentletask.throughline(name="outer"), gentletask.throughline(name="inner"):
+        opts = tc._call_opts_provider()
+    assert opts[tl.OPTS_KEY] == ({"name": "outer"}, {"name": "inner"})
+
+
+def test_provider_returns_none_without_frames():
+    """Outside any throughline frame, the provider contributes nothing."""
+    opts = tc._call_opts_provider()
+    assert not opts
+
+
+# ---------------------------------------------------------------------------
+# Hook: server re-establishes frames before the call runs
+# ---------------------------------------------------------------------------
+
+
+def test_hook_reestablishes_frames():
+    """The context hook installs the transferred frames onto the server throughline."""
+    seen = []
+    cm = ts._call_context_hook({tl.OPTS_KEY: ({"name": "a"}, {"name": "b"})})
+    with cm:
+        seen.append(gentletask.task_chain())
+    assert seen == [("a", "b")]
+    # Frames are torn down on exit.
+    assert gentletask.task_chain() == ()
+
+
+def test_hook_replaces_rather_than_appends_server_frames():
+    """restore() HIDES the server's own pre-existing frames (replace, not append).
+
+    The previous ExitStack implementation appended, leaving the server's frames
+    visible beneath the transferred ones; restore() replaces for the duration of
+    the call and resets on exit.
+    """
+    with gentletask.throughline(name="server_local"):
+        cm = ts._call_context_hook({tl.OPTS_KEY: ({"name": "from_client"},)})
+        with cm:
+            # Only the transferred frame is visible; the server's own is hidden.
+            assert gentletask.task_chain() == ("from_client",)
+        # The server's own frame is restored after the call.
+        assert gentletask.task_chain() == ("server_local",)
+
+
+def test_hook_without_frames_is_noop():
+    """Opts lacking the throughline key leave the server throughline untouched."""
+    cm = ts._call_context_hook({"obj": object()})
+    with cm:
+        assert gentletask.task_chain() == ()
+
+
+# ---------------------------------------------------------------------------
+# In-process round trip (provider -> hook)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_to_hook_roundtrip():
+    """Frames emitted by the provider re-establish identically through the hook."""
+    with gentletask.throughline(name="op"), gentletask.throughline(name="step"):
+        opts = tc._call_opts_provider()
+
+    chain = []
+    with ts._call_context_hook(opts):
+        chain.append(gentletask.task_chain())
+    assert chain == [("op", "step")]
+
+
+# ---------------------------------------------------------------------------
+# Cross-process: the child's throughline shows the parent's ancestry
+# ---------------------------------------------------------------------------
+
+
+def test_cross_process_throughline_ancestry():
+    """A remote call run under a parent throughline sees the full ancestry in the child.
+
+    Propagation is opt-in, so both ends must enable it: the parent (provider)
+    via the autouse fixture, and the child (hook) via an explicit remote call
+    into the child's own ``teleprox.throughline.enable_throughline_propagation``
+    before the asserted call.  The child defines a helper that logs its
+    task_chain; called under the parent's frames, it should report them.
+    """
+    with RemoteLogRecorder("test_throughline_xproc") as recorder:
+        proc = teleprox.start_process(
+            name="test_throughline_child", log_addr=recorder.address
+        )
+        try:
+            # Enable propagation in the child so its server installs the context
+            # hook.  teleprox has no per-child init seam, so we drive it as a
+            # remote call before the call we assert on.
+            proc.client._import("teleprox.throughline").enable_throughline_propagation()
+
+            # Define a remote function that logs the throughline it is running under.
+            proc.client._import("builtins").exec(
+                "def _report_chain():\n"
+                "    import logging, gentletask\n"
+                "    logging.getLogger().warning('chain:' + ','.join(gentletask.task_chain()))\n"
+                "import builtins as _b; _b._report_chain = _report_chain\n"
+            )
+            report = proc.client._import("builtins")._report_chain
+            with gentletask.throughline(name="parent_op"), gentletask.throughline(
+                name="parent_step"
+            ):
+                report()
+        finally:
+            proc.stop()
+
+    assert recorder.find_message("chain:parent_op,parent_step") is not None

--- a/teleprox/throughline.py
+++ b/teleprox/throughline.py
@@ -1,0 +1,108 @@
+# Propagation of gentletask's throughline (semantic task narrative) across the
+# teleprox process boundary, built on the call-opts provider / context-hook seam.
+#
+# When enabled, a client serializes its current throughline frames into each
+# outgoing call's opts; the server re-establishes those frames on its own
+# throughline singleton for the duration of the call, so task_chain() and
+# log filters on the remote side show the full ancestry of the operation.
+#
+# gentletask is an optional dependency: if it is not importable, enabling
+# propagation is a no-op and teleprox behaves exactly as before.
+#
+# Propagation is OPT-IN. Nothing happens at import; a process must call
+# ``enable_throughline_propagation()`` explicitly, once, to wire it up. Because
+# the client opts-provider and server context-hook are PROCESS-GLOBAL single
+# slots (teleprox's ``set_call_opts_provider`` / ``set_call_context_hook``
+# seam), enabling propagation here claims those slots and is therefore mutually
+# exclusive with any other code that registers its own provider/hook. To get
+# end-to-end propagation, BOTH the client process AND any server/child process
+# that should re-establish the context must call
+# ``enable_throughline_propagation()``.
+import contextlib
+
+try:
+    import gentletask
+except ImportError:  # pragma: no cover - exercised only when gentletask is absent
+    gentletask = None
+
+from . import client as _client
+from . import server as _server
+
+# Opts key under which the serialized throughline frames travel. Frames are a
+# tuple of plain ``{'name': ...}`` dicts (see SemanticStack.frames()), which the
+# default serializers handle directly.
+OPTS_KEY = "_throughline_frames"
+
+
+def _opts_provider():
+    """Provider for set_call_opts_provider: emit the caller's throughline frames.
+
+    Returns an empty dict when there are no frames so the merge in
+    ``RPCClient.call_obj`` adds nothing.
+    """
+    if gentletask is None:
+        return None
+    frames = gentletask.throughline.frames()
+    if not frames:
+        return {}
+    return {OPTS_KEY: frames}
+
+
+@contextlib.contextmanager
+def _context_hook(opts):
+    """Hook for set_call_context_hook: re-establish transferred frames, if any.
+
+    Replays the transferred frames onto the server's throughline for the
+    duration of the wrapped call via ``throughline.restore()``, then resets.
+    Calls that carried no frames (or when gentletask is unavailable) run under
+    an unchanged throughline.
+
+    ``restore()`` bypasses the ``required``-key validation that ``throughline``
+    enforces on entry, so propagation no longer depends on the client and
+    server agreeing on identical ``required`` sets.
+
+    NOTE: restore() REPLACES the stack for the block rather than appending to
+    it -- any throughline frames the server already had on this thread are
+    HIDDEN for the call duration and restored on exit. The previous
+    implementation appended (the server's own frames remained visible beneath
+    the transferred ones).
+    """
+    frames = opts.get(OPTS_KEY) if opts else None
+    if gentletask is None or not frames:
+        yield
+        return
+    with gentletask.throughline.restore(frames):
+        yield
+
+
+def enable_throughline_propagation():
+    """Wire throughline propagation into this process's client and server.
+
+    Registers the opts provider (client side) and context hook (server side).
+    A no-op if gentletask is not installed. Safe to call repeatedly.
+
+    Must be called EXPLICITLY (propagation is opt-in; it is not enabled at
+    import). Call it ONCE per process. For end-to-end propagation it must run
+    in BOTH the client process and any server/child process that should
+    re-establish the transferred context.
+
+    This claims the process-global single provider/hook slots and is therefore
+    mutually exclusive with any other user of teleprox's
+    ``set_call_opts_provider`` / ``set_call_context_hook`` seam.
+    """
+    if gentletask is None:
+        return
+    _client.set_call_opts_provider(_opts_provider)
+    _server.set_call_context_hook(_context_hook)
+
+
+def disable_throughline_propagation():
+    """Remove throughline propagation hooks installed by enable_*.
+
+    Clears the provider and hook only if they are the ones we installed, so a
+    user who registered their own provider/hook is left untouched.
+    """
+    if _client._call_opts_provider is _opts_provider:
+        _client.set_call_opts_provider(None)
+    if _server._call_context_hook is _context_hook:
+        _server.set_call_context_hook(None)


### PR DESCRIPTION
Wires the gentletask **throughline** (a stack of task-name frames identifying the operation a log line belongs to) through teleprox's cross-process logging, as part of replacing acq4's homegrown `Future` with gentletask.

## What's here

- **Opt-in throughline propagation across processes** (`teleprox/throughline.py`): a client-side opts provider serializes the caller's current throughline frames into call opts, and a server-side context hook re-establishes them for the duration of the remote call via `gentletask.throughline.restore()`. Wired through the existing `set_call_opts_provider()` / `set_call_context_hook()` seam, gated behind an explicit `enable_throughline_propagation()` (no import-time auto-wiring); a no-op when gentletask isn't installed.
- **`LogSender` tags records with the throughline** at emit time, in the originating thread, so a remote process's task context travels to the log server (the send loop runs on a separate thread with no context). Set only when absent, so an upstream filter's value is preserved.
- **Log viewer shows the throughline as a default column** (renamed from the unused Task column), joined with ` > `.
- **Failed remote calls keep the throughline in their error log**: the server's "Exception while processing request N" record is logged after the call's context window has closed; the error path re-establishes the context hook while logging so the failure record carries the same chain a successful call would.
- **`LogSender.close()` flushes the sender thread** before closing the socket, so queued records are delivered when a process exits quickly.

## Tests

`teleprox/tests/test_throughline.py` covers the provider, the context hook (including replace-not-append semantics), the in-process round trip, cross-process ancestry, and the cross-process error-log path. Full log/throughline suite passes.

## Related

- Display gap filed separately: #34 (HTML export omits the throughline detail row for exception records; the live viewer column shows it).

🤖 Generated with [Claude Code](https://claude.ai/code)