### PR TITLE
Failed remote calls keep their context hook in the error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `LogSender.close()` now joins the sender thread before closing the socket, ensuring all queued log records are delivered when a process exits quickly
+- A failed remote call's "Exception while processing request" error log now re-establishes the call's context hook while logging, so the failure record carries the same context (e.g. a tracing context) a successful call would; previously the hook's context window had already closed
 
 ## [2.2.1]
 

--- a/teleprox/server.py
+++ b/teleprox/server.py
@@ -300,12 +300,17 @@ class RPCServer(object):
             # failed call's error record carries the same context the call ran
             # under. The hook was active only inside process_action's `with
             # call_cm` and is gone by the time control reaches here.
-            if _call_context_hook is not None and action == 'call_obj' and opts:
-                err_ctx = _call_context_hook(opts)
-            else:
-                err_ctx = contextlib.nullcontext()
-            with err_ctx:
-                logger.exception("    => Exception while processing request %d", req_id)
+            err_ctx = contextlib.nullcontext()
+            if _call_context_hook is not None and action == 'call_obj' and isinstance(opts, dict):
+                try:
+                    err_ctx = _call_context_hook(opts)
+                except Exception:
+                    err_ctx = contextlib.nullcontext()
+            try:
+                with err_ctx:
+                    logger.error("    => Exception while processing request %d", req_id, exc_info=exc)
+            except Exception:
+                logger.error("    => Exception while processing request %d", req_id, exc_info=exc)
 
         # Send result or error back to client
         if req_id >= 0:

--- a/teleprox/server.py
+++ b/teleprox/server.py
@@ -275,6 +275,7 @@ class RPCServer(object):
         self._clients[caller] = ser_type
 
         # Attempt to read message and invoke requested action
+        opts = None
         try:
             try:
                 ser = self._serializers[ser_type]
@@ -293,8 +294,18 @@ class RPCServer(object):
             result = self.process_action(action, opts, return_type, caller)
             exc = None
         except Exception:
-            logger.exception("    => Exception while processing request %d", req_id)
             exc = sys.exc_info()
+            # Re-establish the call's semantic context (whatever the registered
+            # context hook installs, e.g. a tracing context) while logging, so a
+            # failed call's error record carries the same context the call ran
+            # under. The hook was active only inside process_action's `with
+            # call_cm` and is gone by the time control reaches here.
+            if _call_context_hook is not None and action == 'call_obj' and opts:
+                err_ctx = _call_context_hook(opts)
+            else:
+                err_ctx = contextlib.nullcontext()
+            with err_ctx:
+                logger.exception("    => Exception while processing request %d", req_id)
 
         # Send result or error back to client
         if req_id >= 0:

--- a/teleprox/tests/test_call_hooks.py
+++ b/teleprox/tests/test_call_hooks.py
@@ -262,9 +262,11 @@ def test_failed_call_error_log_runs_under_context_hook():
     server_logger.addFilter(trace_filter)
     server_logger.addHandler(handler)
 
-    server = RPCServer()
-    client = RPCClient(server.address)
+    client = None
     try:
+        server = RPCServer()
+        client = RPCClient(server.address)
+
         # Define a remote callable that raises, then call it.
         client._import('builtins').exec(
             "def _boom():\n"
@@ -274,10 +276,10 @@ def test_failed_call_error_log_runs_under_context_hook():
         with pytest.raises(Exception):
             client._import('builtins')._boom()
     finally:
-        client.close_server()
+        if client is not None:
+            client.close_server()
         server_logger.removeHandler(handler)
         server_logger.removeFilter(trace_filter)
-
     rec = handler.find_message("Exception while processing request")
     assert rec is not None
     # Without the error-path context restore this would be None.

--- a/teleprox/tests/test_call_hooks.py
+++ b/teleprox/tests/test_call_hooks.py
@@ -1,5 +1,6 @@
 # Tests for process-level call hooks: set_call_opts_provider and set_call_context_hook.
 import contextlib
+import logging
 import threading
 import time
 
@@ -9,7 +10,7 @@ import teleprox.client as tc
 import teleprox.server as ts
 from teleprox import RPCClient, RPCServer
 from teleprox.util import ProcessCleaner
-from teleprox.tests.util import RemoteLogRecorder
+from teleprox.tests.util import RecordingLogHandler, RemoteLogRecorder
 
 
 @pytest.fixture(autouse=True)
@@ -222,3 +223,62 @@ def test_cross_process_opts_and_hook():
             proc.stop()
 
     assert recorder.find_message('hook_trace:from-parent') is not None
+
+
+# ---------------------------------------------------------------------------
+# Failed-call error logging runs under the restored context hook
+# ---------------------------------------------------------------------------
+
+def test_failed_call_error_log_runs_under_context_hook():
+    """A failing call's server-side error log is emitted under the call's context.
+
+    Regression: the "Exception while processing request" record is logged in
+    _process_one *after* process_action's `with call_cm` has already exited.
+    The error path must re-establish the context hook so the failure record
+    carries whatever the hook installed (here, a trace id stamped onto records
+    by a logging filter), rather than logging with the context torn down.
+    """
+    active = threading.local()
+
+    @contextlib.contextmanager
+    def hook(opts):
+        active.value = opts.get('_trace')
+        try:
+            yield
+        finally:
+            active.value = None
+
+    class TraceFilter(logging.Filter):
+        def filter(self, record):
+            record.trace = getattr(active, 'value', None)
+            return True
+
+    tc.set_call_opts_provider(lambda: {'_trace': 'tid-42'})
+    ts.set_call_context_hook(hook)
+
+    server_logger = logging.getLogger('teleprox.server')
+    trace_filter = TraceFilter()
+    handler = RecordingLogHandler()
+    server_logger.addFilter(trace_filter)
+    server_logger.addHandler(handler)
+
+    server = RPCServer()
+    client = RPCClient(server.address)
+    try:
+        # Define a remote callable that raises, then call it.
+        client._import('builtins').exec(
+            "def _boom():\n"
+            "    raise ValueError('boom')\n"
+            "import builtins as _b; _b._boom = _boom\n"
+        )
+        with pytest.raises(Exception):
+            client._import('builtins')._boom()
+    finally:
+        client.close_server()
+        server_logger.removeHandler(handler)
+        server_logger.removeFilter(trace_filter)
+
+    rec = handler.find_message("Exception while processing request")
+    assert rec is not None
+    # Without the error-path context restore this would be None.
+    assert rec.trace == 'tid-42'


### PR DESCRIPTION
A failed remote call's `Exception while processing request N` record is logged in `_process_one`'s `except` block — **after** `process_action`'s `with call_cm` context window has already closed. The call ran under the registered context hook (`set_call_context_hook`), but the failure log did not: it emitted with the context torn down.

This re-establishes the call's context hook while logging the failure, so the error record carries the same context (e.g. a tracing context) a successful call would.

## Changes
- `server.py`: in `_process_one`, re-open the context hook around the `logger.exception(...)` for failed `call_obj` requests (and initialize `opts` before the `try` so it's always bound in the `except`).
- `tests/test_call_hooks.py`: gentletask-free regression test — a hook stamps a trace id onto records via a logging filter; the test asserts the failure record carries it (and confirms it would be empty without the fix).
- CHANGELOG entry.

Fully generic — no dependency on any particular context-hook implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)