### PR TITLE
Close RPC client sockets when the owning thread stops

### DIFF
--- a/teleprox/client.py
+++ b/teleprox/client.py
@@ -50,6 +50,21 @@ def set_call_opts_provider(fn):
 _thread_clients = threading.local()
 
 
+def _safe_close_client(client, context):
+    """Close *client*, swallowing errors and skipping interpreter shutdown.
+
+    Closing zmq sockets (or routing log records through teardown-time handlers)
+    during interpreter finalization is unsafe, so we never close then. *context*
+    names the calling cleanup path for the debug log.
+    """
+    if client is None or sys.is_finalizing():
+        return
+    try:
+        client.close()
+    except Exception:
+        logger.debug("Error closing RPC client during %s", context, exc_info=True)
+
+
 class _ThreadClientCleanup:
     """Sentinel stored in thread-local storage to close RPC clients at thread exit.
 
@@ -57,6 +72,9 @@ class _ThreadClientCleanup:
     storage, dropping this sentinel. Its ``__del__`` then closes every RPC client
     created on that thread, releasing their zmq sockets from the thread that owned
     them.
+
+    This is the primary of three cleanup paths for a client socket; see
+    :meth:`RPCClient.close` for how the Thread-GC backstop and ``__del__`` relate.
     """
 
     def __init__(self):
@@ -66,16 +84,8 @@ class _ThreadClientCleanup:
         self._client_refs.append(weakref.ref(client))
 
     def __del__(self):
-        # Skip during interpreter shutdown; closing zmq sockets then is unsafe.
-        if sys.is_finalizing():
-            return
         for ref in self._client_refs:
-            client = ref()
-            if client is not None:
-                try:
-                    client.close()
-                except Exception:
-                    logger.debug("Error closing RPC client during thread cleanup", exc_info=True)
+            _safe_close_client(ref(), "thread cleanup")
 
 
 def _register_thread_client(client):
@@ -198,12 +208,7 @@ class RPCClient(object):
         already do so. ``close()`` is idempotent, so this is safe even when the
         client was already closed at thread exit.
         """
-        client = client_ref()
-        if client is not None:
-            try:
-                client.close()
-            except Exception:
-                logger.debug("Error closing RPC client during thread finalize", exc_info=True)
+        _safe_close_client(client_ref(), "thread finalize")
 
     def __init__(
         self,
@@ -249,7 +254,15 @@ class RPCClient(object):
                 )
             RPCClient.clients_by_thread[key] = self
         _client_ref = weakref.ref(self)
-        weakref.finalize(threading.current_thread(), RPCClient._forget_client_ref, _client_ref)
+        # Backstop for the thread-stop sentinel: if the Thread object is GC'd
+        # while the program is running, close the client too. atexit=False keeps
+        # this from forcing socket/logging teardown during interpreter shutdown,
+        # where weakref.finalize would otherwise still run with is_finalizing()
+        # False; shutdown cleanup is left to __del__ and RPCServer's atexit.
+        finalizer = weakref.finalize(
+            threading.current_thread(), RPCClient._forget_client_ref, _client_ref
+        )
+        finalizer.atexit = False
         try:
             # Make sure we can reach this address and there is an open socket
             port_status = self.check_address(address)

--- a/teleprox/client.py
+++ b/teleprox/client.py
@@ -44,6 +44,49 @@ def set_call_opts_provider(fn):
     _call_opts_provider = fn
 
 
+# Per-thread registry of RPC clients, used to close their zmq sockets promptly
+# when the owning thread stops running rather than waiting for the Thread object
+# to be garbage-collected (which may never happen if a reference to it lingers).
+_thread_clients = threading.local()
+
+
+class _ThreadClientCleanup:
+    """Sentinel stored in thread-local storage to close RPC clients at thread exit.
+
+    When a thread stops running, the interpreter tears down that thread's local
+    storage, dropping this sentinel. Its ``__del__`` then closes every RPC client
+    created on that thread, releasing their zmq sockets from the thread that owned
+    them.
+    """
+
+    def __init__(self):
+        self._client_refs = []
+
+    def add(self, client):
+        self._client_refs.append(weakref.ref(client))
+
+    def __del__(self):
+        # Skip during interpreter shutdown; closing zmq sockets then is unsafe.
+        if sys.is_finalizing():
+            return
+        for ref in self._client_refs:
+            client = ref()
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    logger.debug("Error closing RPC client during thread cleanup", exc_info=True)
+
+
+def _register_thread_client(client):
+    """Register *client* to be closed when its owning thread stops running."""
+    cleanup = getattr(_thread_clients, 'cleanup', None)
+    if cleanup is None:
+        cleanup = _ThreadClientCleanup()
+        _thread_clients.cleanup = cleanup
+    cleanup.add(client)
+
+
 class RPCClient(object):
     """Connection to an :class:`RPCServer`.
 
@@ -149,10 +192,18 @@ class RPCClient(object):
 
     @classmethod
     def _forget_client_ref(cls, client_ref):
-        """Called when the owning thread is GC'd; forget the client if it still exists."""
+        """Backstop run when the owning Thread object is GC'd.
+
+        Closes the client (and its socket) if the thread-stop cleanup did not
+        already do so. ``close()`` is idempotent, so this is safe even when the
+        client was already closed at thread exit.
+        """
         client = client_ref()
         if client is not None:
-            cls.forget_client(client)
+            try:
+                client.close()
+            except Exception:
+                logger.debug("Error closing RPC client during thread finalize", exc_info=True)
 
     def __init__(
         self,
@@ -164,6 +215,11 @@ class RPCClient(object):
         """Initialize a new RPCClient."""
         if isinstance(address, str):
             address = address.encode()
+
+        # Guards making close() idempotent and safe to call from multiple
+        # cleanup paths (thread-stop sentinel, Thread GC backstop, __del__).
+        self._is_closed = False
+        self._close_lock = threading.Lock()
 
         # pick a unique name: host.pid.tid:rpc_addr
         self.name = f"{log.get_host_name()}.{log.get_process_name()}.{log.get_thread_name()}:{address.decode()}".encode()
@@ -235,6 +291,9 @@ class RPCClient(object):
         except Exception:
             RPCClient.clients_by_thread.pop(key, None)
             raise
+
+        # Close this client's socket when the owning thread stops running.
+        _register_thread_client(self)
 
     @staticmethod
     def check_address(address, timeout=1.0):
@@ -682,12 +741,22 @@ class RPCClient(object):
         return self.send('ping', sync=sync, **kwds)
 
     def close(self):
-        """Close this client's socket (but leave the server running)."""
+        """Close this client's socket (but leave the server running).
+
+        Idempotent: may be called from the owning thread's stop cleanup, the
+        Thread GC backstop, or ``__del__`` without closing twice.
+        """
+        with self._close_lock:
+            if self._is_closed:
+                return
+            self._is_closed = True
         # reference management is disabled for now..
         # self.send('release_all', return_type=None)
-        self._socket.close()
+        socket = getattr(self, '_socket', None)
+        if socket is not None:
+            socket.close()
         RPCClient.forget_client(self)
-        if self._manage_local_server:
+        if getattr(self, '_manage_local_server', False):
             self._local_server.close()
 
     def close_server(self, sync='sync', timeout=1.0, **kwds):

--- a/teleprox/tests/test_rpc.py
+++ b/teleprox/tests/test_rpc.py
@@ -946,12 +946,49 @@ def test_thread_del_closes_socket():
     thread.join()
 
     socket = thread._socket
-    assert not socket.closed
 
+    # Cleanup happens when the thread stops running; dropping the Thread object
+    # and forcing GC must be a harmless (idempotent) backstop that leaves the
+    # socket closed.
     del thread
     gc.collect()
 
-    assert socket.closed, "thread.__del__ should have closed the socket via close()"
+    assert socket.closed, "thread cleanup should have closed the socket via close()"
+
+    server.close()
+
+
+def test_thread_stop_closes_socket():
+    """A thread's RPC client socket is closed when the thread STOPS running,
+    even while a reference to the Thread object is still held.
+
+    This is the file-handle leak guard: under heavy multi-threaded cross-process
+    use, Thread objects routinely linger (in pools, lists, frames), so cleanup
+    must not depend on the Thread object being garbage-collected.
+    """
+    server = RPCServer()
+
+    class ClientThread(threading.Thread):
+        def __init__(self, addr):
+            super().__init__(daemon=True)
+            self.addr = addr
+
+        def run(self):
+            self._socket = RPCClient(self.addr)._socket
+
+    thread = ClientThread(server.address)
+    thread.start()
+    thread.join()
+
+    socket = thread._socket
+
+    # We deliberately keep `thread` alive for the whole test; the socket must
+    # still be closed because the owning thread has stopped running.
+    deadline = time.time() + 2.0
+    while not socket.closed and time.time() < deadline:
+        time.sleep(0.01)
+    assert socket.closed, "stopping the thread should have closed its RPC client socket"
+    assert thread is not None  # ensure the Thread object was never collected
 
     server.close()
 

--- a/teleprox/tests/test_rpc.py
+++ b/teleprox/tests/test_rpc.py
@@ -982,13 +982,67 @@ def test_thread_stop_closes_socket():
 
     socket = thread._socket
 
-    # We deliberately keep `thread` alive for the whole test; the socket must
-    # still be closed because the owning thread has stopped running.
+    # We never drop our reference to `thread`, so the Thread object cannot be
+    # garbage-collected; the socket must still close because the owning thread
+    # has stopped running.
     deadline = time.time() + 2.0
     while not socket.closed and time.time() < deadline:
         time.sleep(0.01)
     assert socket.closed, "stopping the thread should have closed its RPC client socket"
-    assert thread is not None  # ensure the Thread object was never collected
+
+    server.close()
+
+
+def test_thread_stop_closes_multiple_client_sockets():
+    """All RPC clients created on one thread are closed when that thread stops.
+
+    Exercises the sentinel's list of per-thread clients (one socket per remote
+    server address).
+    """
+    server1 = RPCServer()
+    server2 = RPCServer()
+
+    class ClientThread(threading.Thread):
+        def __init__(self, addrs):
+            super().__init__(daemon=True)
+            self.addrs = addrs
+
+        def run(self):
+            self._sockets = [RPCClient(addr)._socket for addr in self.addrs]
+
+    thread = ClientThread([server1.address, server2.address])
+    thread.start()
+    thread.join()
+
+    sockets = thread._sockets
+    assert len(sockets) == 2
+
+    deadline = time.time() + 2.0
+    while not all(s.closed for s in sockets) and time.time() < deadline:
+        time.sleep(0.01)
+    assert all(s.closed for s in sockets), "stopping the thread should close every client socket"
+
+    server1.close()
+    server2.close()
+
+
+def test_close_is_idempotent():
+    """Calling RPCClient.close() more than once is a harmless no-op.
+
+    Multiple cleanup paths (thread-stop sentinel, Thread-GC backstop, __del__)
+    can each call close(); the second and later calls must not raise.
+    """
+    server = RPCServer()
+    client = RPCClient(server.address)
+    socket = client._socket
+
+    client.close()
+    assert socket.closed
+
+    # Second close must not raise (e.g. re-closing the socket or re-closing a
+    # managed local server).
+    client.close()
+    assert socket.closed
 
     server.close()
 


### PR DESCRIPTION
## Problem

zmq runs out of file handles under heavy multi-threaded cross-process teleprox use. Each thread that talks to a remote process gets its own `RPCClient` with a dedicated zmq `DEALER` socket (one fd). Cleanup relied on `weakref.finalize(threading.current_thread(), ...)`, which only fires when the **`Thread` object is garbage-collected** — not when the thread stops running. In real apps `Thread` objects routinely linger (pools, lists, traceback frames), so sockets were never released and fds piled up.

The existing test suite even documented the leak: `test_thread_del_closes_socket` asserted `not socket.closed` immediately after `thread.join()` — i.e. a stopped thread kept its socket open until the `Thread` was `del`'d and GC ran.

## Fix

- **Thread-local sentinel** (`_ThreadClientCleanup`): when a thread stops, the interpreter tears down its thread-local storage, dropping the sentinel; its `__del__` closes every RPC client created on that thread — running in the owning thread, the correct place to close a zmq socket. Each client registers via `_register_thread_client(self)` at the end of `__init__`.
- **Idempotent `close()`**: guarded by `_is_closed` + a lock and tolerant of partial init, so the three cleanup paths (thread-stop sentinel, Thread-GC backstop, `__del__`) can't double-close.
- **GC backstop upgrade**: `_forget_client_ref` now calls `client.close()` (releasing the socket in one pass) instead of merely forgetting the cached client.

## Tests

- **New `test_thread_stop_closes_socket`** — joins a worker thread and asserts the socket closes **while still holding the `Thread` reference**. Red before the change, green after.
- **Updated `test_thread_del_closes_socket`** — dropped the stale `assert not socket.closed` (it encoded the buggy behavior); now verifies del+GC remains a harmless idempotent backstop.

Results: `test_rpc.py` 28 passed; full `teleprox/` suite 151 passed, 1 skipped. One unrelated pre-existing flake (`test_lazy_servers_fail_at_async_callbacks`, see #37) and pre-existing server-leak atexit warnings (#38) were filed as separate issues rather than fixed here.

🧙 Built with [WOZCODE](https://wozcode.com)