### PR TITLE
Harden RPCServer against concurrent zmq socket access (issue #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `RPCServer` now refuses to start a second `run_forever` thread on one socket (via `_run_in_thread()` or a direct `run_forever()` call), raising `RuntimeError` instead of silently corrupting the socket's multipart framing; two threads reading one zmq socket is unsupported (issue #40)
+- `run_forever` now logs and skips a malformed/partial RPC message instead of letting the `ValueError` escape and kill the server thread, which previously left the process alive but deaf on teleprox (issue #40)
+
 ## [2.2.2]
 
 ### Fixed

--- a/repro_issue_40.py
+++ b/repro_issue_40.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+"""Reproduce teleprox issue #40: framing corruption from two threads on one zmq socket.
+
+This replicates what ACQ4 does wrong in ``acq4/__main__.py``::
+
+    teleprox_debug_server = RPCServer(addr)   # run_thread defaults True -> starts run_forever thread #1
+    teleprox_debug_server._run_in_thread()    # starts run_forever thread #2 on the SAME socket
+
+``RPCServer.__init__`` already starts a ``run_forever`` thread when ``run_thread=True``
+(the default), so calling ``_run_in_thread()`` again leaves TWO daemon threads both
+calling ``recv_multipart()`` on the same ROUTER socket. libzmq sockets are not
+thread-safe, so the two readers steal frames from each other: one ``run_forever`` loop
+receives a partial multipart message and raises ``ValueError: Invalid RPC message:
+expected 6 parts, got N`` (killing that server thread -> "goes deaf"), and intermittently
+the concurrent access trips the fatal libzmq ``Assertion failed: false (src/object.cpp:142)``
+SIGABRT instead.
+
+The server runs in a subprocess (as it does inside ACQ4) so a potential SIGABRT does not
+take down the harness, and we can watch its stderr for the framing error.
+
+Usage::
+
+    python repro_issue_40.py            # buggy: double run_forever -> corruption within seconds
+    python repro_issue_40.py --fixed    # single run_forever -> no corruption (control)
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+import threading
+import time
+
+
+# ---------------------------------------------------------------------------
+# Server subprocess: stands in for the ACQ4 process running `--teleprox`.
+# ---------------------------------------------------------------------------
+SERVER_SRC = r'''
+import sys, time
+from teleprox import RPCServer
+
+buggy = "--fixed" not in sys.argv
+
+# RPCServer(run_thread=True) already starts one run_forever thread inside __init__.
+server = RPCServer("tcp://127.0.0.1:*")
+if buggy:
+    # This is exactly what acq4/__main__.py does: start a SECOND run_forever
+    # thread on the same socket. Two threads now recv_multipart() concurrently.
+    server._run_in_thread()
+
+# Announce the address on stdout so the parent can connect.
+print("ADDR " + server.address.decode(), flush=True)
+
+# Sit alive like the ACQ4 process would.
+while True:
+    time.sleep(0.5)
+'''
+
+
+def run_server():
+    """Spawn the stand-in ACQ4 server subprocess and return its Popen handle."""
+    args = [sys.executable, "-c", SERVER_SRC]
+    if "--fixed" in sys.argv:
+        args.append("--fixed")
+    return subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+
+def worker(addr, stop, stats, idx):
+    """Hammer the server like the MCP client does: import a module + call it.
+
+    Each iteration sends two requests (import + call), matching the
+    interleaving of import/call/ping frames seen in the ticket.
+    """
+    from teleprox import RPCClient
+
+    client = RPCClient.get_client(addr)          # per-thread client
+    mod = client._import("os")                    # any importable module
+    n = 0
+    while not stop.is_set():
+        try:
+            mod.getpid()                          # any cheap remote call
+            n += 1
+        except Exception as exc:
+            stats[idx] = (n, repr(exc))
+            return
+    stats[idx] = (n, None)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixed", action="store_true",
+                        help="start only one run_forever thread (control: no corruption)")
+    parser.add_argument("--threads", type=int, default=4, help="number of client threads")
+    parser.add_argument("--duration", type=float, default=20.0, help="seconds to hammer")
+    ns = parser.parse_args()
+
+    proc = run_server()
+
+    # Wait for the server to announce its address.
+    addr = None
+    for _ in range(200):
+        line = proc.stdout.readline()
+        if line.startswith("ADDR "):
+            addr = line[5:].strip()
+            break
+        if proc.poll() is not None:
+            break
+    if addr is None:
+        print("server failed to start; stderr:\n" + proc.stderr.read())
+        proc.kill()
+        return 2
+
+    mode = "fixed (single run_forever)" if ns.fixed else "buggy (double run_forever)"
+    print(f"server pid={proc.pid} listening at {addr}")
+    print(f"mode={mode}  threads={ns.threads}  duration={ns.duration}s")
+
+    # Collect server stderr in the background so we can scan it for the framing error.
+    server_err = []
+    err_thread = threading.Thread(
+        target=lambda: server_err.extend(iter(proc.stderr.readline, "")), daemon=True
+    )
+    err_thread.start()
+
+    nthreads = ns.threads
+    duration = ns.duration
+    stop = threading.Event()
+    stats = {}
+    threads = [
+        threading.Thread(target=worker, args=(addr, stop, stats, i))
+        for i in range(nthreads)
+    ]
+    for t in threads:
+        t.start()
+
+    # Watch for the server to die, emit the framing error, or any client worker to
+    # blow up on corrupted frames, up to `duration`.
+    start = time.time()
+    verdict = None
+    while time.time() - start < duration:
+        time.sleep(0.25)
+        code = proc.poll()
+        if code is not None:
+            if code < 0:
+                verdict = f"server process died with signal {-code} (SIGABRT=6 => libzmq object.cpp:142)"
+            else:
+                verdict = f"server process exited with code {code}"
+            break
+        joined = "".join(server_err)
+        if "Invalid RPC message" in joined:
+            verdict = "server logged 'Invalid RPC message' (server-side multipart framing corrupted)"
+            break
+        # Client-side face of the same defect: a worker got a corrupted/merged reply
+        # (msgpack ExtraData / unpack error) or timed out because a reply was stolen.
+        errored = [(i, e) for i, (_, e) in stats.items() if e]
+        if errored:
+            i, e = errored[0]
+            verdict = f"client thread {i} hit corrupted transport: {e}"
+            break
+
+    stop.set()
+    for t in threads:
+        t.join(timeout=2)
+
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    print("\n--- client results ---")
+    for i in range(nthreads):
+        calls, exc = stats.get(i, (0, "never finished"))
+        print(f"  thread {i}: {calls} calls, error={exc}")
+
+    joined = "".join(server_err)
+    framing = re.findall(r"Invalid RPC message: expected 6 parts, got \d+.*", joined)
+    print("\n--- server stderr (framing errors) ---")
+    if framing:
+        for line in framing[:10]:
+            print("  " + line)
+    else:
+        print("  (none)")
+
+    print("\n--- verdict ---")
+    if verdict:
+        print("  REPRODUCED: " + verdict)
+        return 1
+    print("  no corruption observed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/repro_issue_40.py
+++ b/repro_issue_40.py
@@ -20,8 +20,14 @@ take down the harness, and we can watch its stderr for the framing error.
 
 Usage::
 
-    python repro_issue_40.py            # buggy: double run_forever -> corruption within seconds
+    python repro_issue_40.py            # buggy: double run_forever
     python repro_issue_40.py --fixed    # single run_forever -> no corruption (control)
+
+Against an UNHARDENED teleprox the buggy mode corrupts the transport within
+seconds (client-side ExtraData, server-side 'expected 6 parts', or a SIGABRT).
+Against the hardened teleprox in this repo the buggy mode is instead REFUSED with
+a RuntimeError (verdict: PREVENTED), because RPCServer now guards against starting
+a second run_forever thread on one socket.
 """
 
 import argparse
@@ -112,8 +118,15 @@ def main():
         if proc.poll() is not None:
             break
     if addr is None:
-        print("server failed to start; stderr:\n" + proc.stderr.read())
+        stderr = proc.stderr.read()
         proc.kill()
+        if "already processing requests" in stderr or "run_forever" in stderr:
+            # Hardened teleprox refuses the double _run_in_thread() with a clear
+            # RuntimeError instead of silently spawning a second socket reader.
+            print("\n--- verdict ---")
+            print("  PREVENTED: teleprox refused the double run_forever (issue #40 guard active)")
+            return 0
+        print("server failed to start; stderr:\n" + stderr)
         return 2
 
     mode = "fixed (single run_forever)" if ns.fixed else "buggy (double run_forever)"

--- a/teleprox/server.py
+++ b/teleprox/server.py
@@ -468,17 +468,39 @@ class RPCServer(object):
 
     def run_forever(self):
         """Read and process RPC requests until the server is asked to close."""
-        self._run_thread = threading.current_thread()
+        current = threading.current_thread()
+        if self._run_thread is not None and self._run_thread is not current and self._run_thread.is_alive():
+            raise RuntimeError(
+                "RPCServer is already processing requests in another thread; a second"
+                " run_forever would read the same zmq socket from two threads and"
+                " corrupt its framing (zmq sockets are not thread-safe)."
+            )
+        self._run_thread = current
         logger.log(DEBUG2,
             f"RPC start server loop: {log.get_host_name()}.{log.get_process_name()}.{log.get_thread_name()}"
             f"@{self.address.decode()}"
         )
         while self.running():
-            name, msg = self._read_one(self._socket)
+            try:
+                name, msg = self._read_one(self._socket)
+            except ValueError as exc:
+                # A malformed/partial message (wrong number of multipart frames)
+                # usually means a single zmq socket is being read from more than
+                # one thread, which is not supported. Log and skip it rather than
+                # letting the exception escape and kill this server thread, which
+                # would leave the process alive but deaf on teleprox.
+                logger.warning("Skipping malformed RPC message: %s", exc)
+                continue
             self._process_one(name, msg)
 
     def _run_in_thread(self):
         """Call run_forever in a new thread."""
+        if self._run_thread is not None and self._run_thread.is_alive():
+            raise RuntimeError(
+                "RPCServer is already processing requests in a thread; starting a"
+                " second run_forever thread would read the same zmq socket from two"
+                " threads and corrupt its framing (zmq sockets are not thread-safe)."
+            )
         self._run_thread = threading.Thread(target=self.run_forever, daemon=True)
         self._run_thread.start()
 

--- a/teleprox/tests/test_server.py
+++ b/teleprox/tests/test_server.py
@@ -2,7 +2,10 @@ import logging
 import time
 import numpy as np
 import pytest
+import zmq
 import teleprox
+from teleprox import RPCClient, RPCServer
+from teleprox.tests.util import RecordingLogHandler
 from teleprox.util import ProcessCleaner
 
 
@@ -22,3 +25,78 @@ def test_published_objects():
         assert proc.client['os'].getpid() == proc.pid
 
         proc.stop()
+
+
+def test_double_run_in_thread_raises():
+    """Starting a second run_forever thread on one socket must be refused.
+
+    Two threads reading a single zmq ROUTER socket corrupts its multipart
+    framing (teleprox issue #40), so ``_run_in_thread()`` on a server that is
+    already processing in a thread must raise rather than silently spawn a
+    second concurrent reader.
+    """
+    server = RPCServer('tcp://127.0.0.1:*')  # run_thread=True starts one reader
+    client = RPCClient.get_client(server.address)
+    try:
+        with pytest.raises(RuntimeError):
+            server._run_in_thread()
+        assert client.ping() == 'pong'
+        client.close_server()
+    finally:
+        client.close()
+
+
+def test_second_run_forever_raises():
+    """Calling run_forever on an already-running server must be refused too.
+
+    This closes the direct bypass of the ``_run_in_thread`` guard: starting a
+    second reader via ``threading.Thread(target=server.run_forever)`` would also
+    corrupt the socket (teleprox issue #40). The guard raises synchronously in
+    the calling thread before blocking on the socket.
+    """
+    server = RPCServer('tcp://127.0.0.1:*')  # run_thread=True starts one reader
+    client = RPCClient.get_client(server.address)
+    try:
+        with pytest.raises(RuntimeError):
+            server.run_forever()
+        # The original server thread must be unharmed and still serving.
+        assert client.ping() == 'pong'
+        client.close_server()
+    finally:
+        client.close()
+
+
+def test_run_forever_survives_malformed_message():
+    """A malformed/partial message is logged and skipped, not fatal to run_forever.
+
+    Previously an unhandled ValueError from ``_read_one`` terminated the server
+    thread, leaving the process alive but deaf on teleprox (teleprox issue #40).
+    """
+    # Record the server's warnings directly; the skip is logged from the server's
+    # run_forever thread, which pytest's caplog fixture does not reliably capture.
+    server_logger = logging.getLogger('teleprox.server')
+    handler = RecordingLogHandler()
+    server_logger.addHandler(handler)
+
+    server = RPCServer('tcp://127.0.0.1:*')
+    addr = server.address
+    try:
+        # Send a raw multipart message with the wrong number of parts. The DEALER
+        # prepends its identity frame, so the ROUTER sees 3 parts where 6 are
+        # expected -- exactly the fragmentation reported in the ticket.
+        raw = zmq.Context.instance().socket(zmq.DEALER)
+        raw.connect(addr)
+        raw.send_multipart([b'ping', b'auto'])
+        time.sleep(0.2)  # let the frame deliver and the server process (and skip) it
+        raw.close(linger=0)
+
+        client = RPCClient.get_client(addr)
+        try:
+            # If run_forever died on the malformed message, this ping times out.
+            assert client.ping() == 'pong'
+            assert handler.find_message('malformed RPC message') is not None
+            client.close_server()
+        finally:
+            client.close()
+    finally:
+        server_logger.removeHandler(handler)


### PR DESCRIPTION
## Summary

Fixes teleprox #40, where sustained/concurrent RPC load corrupts the multipart framing — the `RPCServer` receives partial messages (`ValueError: Invalid RPC message: expected 6 parts, got N`, which kills `run_forever`) and intermittently trips a fatal libzmq `object.cpp:142` SIGABRT.

## Root cause

The defect is "two threads reading/writing a single zmq socket" (libzmq sockets are not thread-safe). The concrete trigger was in **acq4** (`acq4/__main__.py`), which the maintainer has since fixed:

```python
teleprox_debug_server = RPCServer(addr)   # run_thread defaults True -> starts run_forever thread #1
teleprox_debug_server._run_in_thread()    # started run_forever thread #2 on the SAME socket
```

`RPCServer.__init__` already starts a `run_forever` thread when `run_thread=True` (the default), so the second `_run_in_thread()` left two daemon threads both calling `recv_multipart()` on one ROUTER socket. This is why the ticket's isolated `start_process` repros never fired — normal usage only ever starts one `run_forever` thread.

## Changes

Hardens teleprox so this misuse can't silently corrupt the transport, per the ticket's two suggestions:

1. **Refuse a second reader on one socket.** Both `_run_in_thread()` and a direct `run_forever()` call now raise `RuntimeError` when a run thread is already alive, instead of silently spawning a second concurrent reader.
2. **Make `run_forever` resilient.** A malformed/partial message (`ValueError` from `_read_one`) is logged and skipped rather than escaping and killing the server thread (which left the process alive but deaf on teleprox). Socket-close errors (`zmq.ZMQError`) still propagate, so normal shutdown is unchanged.

## Tests

- `test_double_run_in_thread_raises` — second `_run_in_thread()` raises; original server keeps serving.
- `test_second_run_forever_raises` — direct `run_forever()` on a running server raises (closes the bypass).
- `test_run_forever_survives_malformed_message` — a raw malformed frame is logged/skipped and the server still answers pings.

Full suite: `71 passed, 1 skipped`.

## Reproduction script

`repro_issue_40.py` documents and drives the defect. Against an **unhardened** teleprox its buggy mode reproduces all three faces within seconds (client-side msgpack `ExtraData`, server-side `expected 6 parts`, and the SIGABRT). Against the **hardened** teleprox in this PR the buggy double-start is instead **refused** with `RuntimeError` (verdict: `PREVENTED`), and the `--fixed` control (single `run_forever`) runs clean.

```
python repro_issue_40.py            # buggy double-start -> PREVENTED (guard active)
python repro_issue_40.py --fixed    # single run_forever  -> no corruption
```

Closes #40

🧙 Built with [WOZCODE](https://wozcode.com)